### PR TITLE
fix: handle EADDRINUSE gracefully on startup

### DIFF
--- a/server/src/__tests__/main-port-conflict.test.ts
+++ b/server/src/__tests__/main-port-conflict.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import http from 'node:http';
+
+/**
+ * Test the listen-then-catch pattern used in main.ts
+ * without involving ExtensionBridge/WSS (which complicates error routing).
+ */
+describe('HTTP server port conflict', () => {
+  let blocker: http.Server | null = null;
+  let testServer: http.Server | null = null;
+
+  afterEach(async () => {
+    for (const s of [blocker, testServer]) {
+      if (s?.listening) {
+        await new Promise<void>((resolve) => s.close(() => resolve()));
+      }
+    }
+    blocker = null;
+    testServer = null;
+  });
+
+  it('should recover gracefully when port is occupied', async () => {
+    const PORT = 18899;
+
+    // Occupy the port
+    blocker = http.createServer();
+    await new Promise<void>((resolve) => {
+      blocker!.listen(PORT, '127.0.0.1', resolve);
+    });
+
+    // Replicate the exact pattern from main.ts
+    testServer = http.createServer();
+    let httpListening = false;
+    let caughtCode: string | undefined;
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        testServer!.once('error', reject);
+        testServer!.listen(PORT, '127.0.0.1', () => {
+          testServer!.removeListener('error', reject);
+          httpListening = true;
+          resolve();
+        });
+      });
+    } catch (err: unknown) {
+      caughtCode = (err as NodeJS.ErrnoException).code;
+      if (caughtCode !== 'EADDRINUSE') throw err;
+    }
+
+    expect(httpListening).toBe(false);
+    expect(caughtCode).toBe('EADDRINUSE');
+  });
+
+  it('should listen successfully when port is free', async () => {
+    const PORT = 18898;
+
+    testServer = http.createServer();
+    let httpListening = false;
+
+    await new Promise<void>((resolve, reject) => {
+      testServer!.once('error', reject);
+      testServer!.listen(PORT, '127.0.0.1', () => {
+        testServer!.removeListener('error', reject);
+        httpListening = true;
+        resolve();
+      });
+    });
+
+    expect(httpListening).toBe(true);
+  });
+});

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -26,13 +26,29 @@ export async function main(): Promise<void> {
   const bridge = new ExtensionBridge(PORT);
   const toolMutex = new Mutex();
 
-  // Start HTTP server + WebSocket
+  // Start HTTP server + WebSocket (attach WSS only after successful listen)
   const httpServer = createHttpServer(bridge);
-  bridge.start(httpServer);
 
-  httpServer.listen(PORT, '127.0.0.1', () => {
-    logger('HTTP + WebSocket server listening on http://127.0.0.1:%d', PORT);
-  });
+  let httpListening = false;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      httpServer.once('error', reject);
+      httpServer.listen(PORT, '127.0.0.1', () => {
+        httpServer.removeListener('error', reject);
+        httpListening = true;
+        bridge.start(httpServer);
+        logger('HTTP + WebSocket server listening on http://127.0.0.1:%d', PORT);
+        resolve();
+      });
+    });
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EADDRINUSE') {
+      logger('Port %d already in use — continuing with MCP stdio only', PORT);
+    } else {
+      throw err;
+    }
+  }
 
   // MCP server
   const server = new McpServer({
@@ -74,7 +90,7 @@ export async function main(): Promise<void> {
     } catch (err) {
       logger('Error closing bridge: %O', err);
     }
-    httpServer.close();
+    if (httpListening) httpServer.close();
     process.exit(0);
   };
 


### PR DESCRIPTION
## Summary

- Catches `EADDRINUSE` when port 18800 is already bound and continues with MCP stdio only
- Defers WebSocketServer attachment to after successful `listen()` to prevent uncaught error propagation
- Adds 2 tests covering both the conflict and happy-path scenarios

## Context

When Claude Code starts the MCP server via stdio, it also tries to bind HTTP+WS on port 18800. If another process holds the port, the server crashed, preventing Claude Code from loading any agent-browse tools.

The HTTP server is a backward-compat layer for external scripts — MCP stdio is the primary transport. Gracefully skipping HTTP when the port is occupied is the right tradeoff.

## Test plan

- [x] 47 tests pass (45 existing + 2 new)
- [x] `tsc --noEmit` clean
- [ ] Restart Claude Code with port 18800 occupied → tools should load
- [ ] Restart Claude Code with port 18800 free → full functionality

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)