### PR TITLE
fix: use dynamic version in HTTP info endpoint

### DIFF
--- a/server/src/http-server.ts
+++ b/server/src/http-server.ts
@@ -7,7 +7,7 @@ import type { ExtensionBridge } from './ExtensionBridge.js';
  * HTTP endpoints for backward compatibility with browse-cli.sh and external scripts.
  * These replicate the original relay_server.py HTTP API.
  */
-export function createHttpServer(bridge: ExtensionBridge): http.Server {
+export function createHttpServer(bridge: ExtensionBridge, version: string = '0.0.0'): http.Server {
   const app = express();
   app.use(express.json());
 
@@ -23,7 +23,7 @@ export function createHttpServer(bridge: ExtensionBridge): http.Server {
   app.get('/', (_req: Request, res: Response) => {
     res.json({
       server: 'agent-browse-mcp',
-      version: '0.1.0',
+      version,
       extensionConnected: bridge.isConnected,
     });
   });

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -32,7 +32,7 @@ export async function main(): Promise<void> {
   const toolMutex = new Mutex();
 
   // Start HTTP server + WebSocket (attach WSS only after successful listen)
-  const httpServer = createHttpServer(bridge);
+  const httpServer = createHttpServer(bridge, SERVER_VERSION);
 
   let httpListening = false;
   try {


### PR DESCRIPTION
## Summary

- Pass `SERVER_VERSION` to `createHttpServer()` instead of hardcoding `'0.1.0'`
- Two lines changed, zero logic change

## Test plan

- [x] 53 tests pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)